### PR TITLE
bugfix/country-conversions-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt_reddit_ads_source v0.4.1
+[PR #11](https://github.com/fivetran/dbt_reddit_ads_source/pull/11) includes the following updates:
+
+## Bug Fix
+- Updates the uniqueness test of the recently introduced `stg_reddit_ads__campaign_country_conversions_report` model to include `event_name`. This is aligned with the other `*_conversions_report` tables in this package.
+
 # dbt_reddit_ads_source v0.4.0
 [PR #10](https://github.com/fivetran/dbt_reddit_ads_source/pull/10) includes the following updates:
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'reddit_ads_source'
-version: '0.4.0'
+version: '0.4.1'
 
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'reddit_ads_source_integration_tests'
-version: '0.4.0'
+version: '0.4.1'
 
 profile: 'integration_tests'
 config-version: 2

--- a/models/stg_reddit_ads.yml
+++ b/models/stg_reddit_ads.yml
@@ -414,6 +414,7 @@ models:
             - campaign_id
             - country
             - date_day
+            - event_name
     columns:
       - name: account_id
         description: '{{ doc("account_id") }}'


### PR DESCRIPTION
<!--
Pre-Submission Reminders  
Before marking this PR as "ready for review":

- `dbt run --full-refresh && dbt test`  
- `dbt run` && `dbt test` (if incremental models are present)  
- The related issue is linked, tagged, and appropriately assigned  
- Documentation and version updates are included, if applicable  
- `docs` have been regenerated (unless there are no code or YAML changes)  
- BuildKite integration tests are passing
-->

## PR Overview 
**Package version introduced in this PR:** 
 v0.4.1

**This PR addresses the following Issue/Feature(s):**
<!-- Add Issue # or internal ticket reference -->
I noticed this failure in my Ad Reporting work here: https://github.com/fivetran/dbt_ad_reporting/pull/144
<img width="635" alt="image" src="https://github.com/user-attachments/assets/595f956c-6fd6-469e-b1f1-fced32a80b56" />

After some minor digging, I realized it was because we didn't include `event_name` in the uniqueness test for the new `stg_reddit_ads__campaign_country_conversions_report` table. We include event_name in [other](https://github.com/fivetran/dbt_reddit_ads_source/blob/main/models/stg_reddit_ads.yml#L259) `*_conversions_report` models.

**Summary of changes:**  
<!-- 1-2 sentences describing PR changes. -->
This PR includes aligns the test on `stg_reddit_ads__campaign_country_conversions_report` with the other conversions report models by adding `event_name` to its grain. 

### Submission Checklist  
- [ ] Alignment meeting with the reviewer (if needed)  
  - [ ] Timeline and validation requirements discussed  
- [x] Provide validation details:  
  - [x] **Validation Steps:** 
  including `event_name` allows the test to pass
<img width="638" alt="image" src="https://github.com/user-attachments/assets/d8089f3f-0f62-4761-b3cb-90d2723349e8" />

  - [x] **Testing Instructions:** `dbt test` on prod, then `dbt test` using this branch. 
  - [ ] **Focus Areas:** Nothin really

### Changelog  
<!-- Recommend drafting changelog notes, then refining via ChatGPT using:  
"Draft a changelog entry based on the following notes." -->
- [x] Draft changelog for PR  
- [ ] Final changelog for release review